### PR TITLE
Filter PR builds to reduce build times

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -7,7 +7,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+     - uses: dorny/paths-filter@v2
+       id: filter
+       with:
+         filters: |
+           artifacts:
+             - '**/*.rs'
+             - Cargo.*
+             - **/Cargo.*
+             - Cross.toml
+             - .github/bin/*
+           docs:
+            - 'docs/**'
   check:
+    needs: [ filter ]
+    if: ${{ needs.filter.outputs.artifacts == 'true' }}
     name: Check
     runs-on: ubuntu-latest
     steps:
@@ -37,14 +57,8 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
+    needs: [ filter ]
+    if: ${{ needs.filter.outputs.docs == 'true' }}
     steps:
-    - uses: dorny/paths-filter@v2
-      id: filter
-      with:
-        filters: |
-          docs:
-            - 'docs/**'
-
     - name: Builds Docs
-      if: ${{ steps.filter.outputs.docs == 'true' }}
       uses: ./.github/workflows/gh-pages.yml


### PR DESCRIPTION
Instead of building the binary for doc only builds, allow the PR to only build the doc site.