### PR TITLE
Add optional required field to DoctorGroup

### DIFF
--- a/docs/docs/models/ScopeDoctorGroup.md
+++ b/docs/docs/models/ScopeDoctorGroup.md
@@ -27,6 +27,7 @@ spec:
       fix:
         commands:
           - ./scripts/fix-node-version.sh
+      required: false
     - description: Install packages
       check:
         paths:
@@ -45,7 +46,6 @@ In the example above, there are two actions, the first ensures that node is oper
 
 An action is a discrete step, they run in order defined.
 The action should be atomic, and target a single resolution.
-If an action fails, the following actions will still run, unless `fix.commands` or `check.commands` exit with an error code `>=100`.
 
 Notice an action can provide both `paths` and `commands`, if either of them indicate that the fix should run, it will run.
 In the event there are no defined check, the fix will _always_ run.
@@ -53,26 +53,17 @@ In the event there are no defined check, the fix will _always_ run.
 ## Fix
 
 When the checks determine that something isn't correct, a fix is the way to automate the resolution.
-When provided, `scope` will run them in order, if a command fails, the next command will continue to run unless the script exists with `>=100`
+When provided, `scope` will run them in order.
 
 ## Commands
 
 A command can either be relative, or use the PATH.
 To target a script relative to the group it must start with `.`, and giving a relative path to the group file.
 
-## Exit Codes
-
-Depending on the exit code, different effects will happen
-
-| Exit Code   | Check Effect                                                       | Fix Effect                                 |
-|-------------|--------------------------------------------------------------------|--------------------------------------------|
-| `0`         | No work needed                                                     | Fix was successful                         |
-| `1 - 99`    | Work required                                                      | Fix ran, but failed                        |
-| `100+`      | Work is required, but fix should not run. Do not run other checks. | Fix ran, failed, and execution should stop |
-
 ## Schema
 
 - `.spec.action` a series of steps to check and fix for the group.
+- `.spec.action[].required` default true, when true action failing check & fix will stop all execution. 
 - `.spec.action[].check.paths` A list of globs to check for a change.
 - `.spec.action[].check.commands` A list of commands to execute, using the exit code to determine if changes are needed.
 - `.spec.action[].fix.commands` A list of commands to execute, attempting to resolve issues detected by the action.

--- a/examples/.scope/doctor-check-fix-in-scope.yaml
+++ b/examples/.scope/doctor-check-fix-in-scope.yaml
@@ -4,7 +4,7 @@ metadata:
   name: path-exists-fix-in-scope-dir
 spec:
   check:
-    target: ./scripts/does-path-env-exist.sh
+    target: ./scripts/fail-first-call path-exists-fix-in-scope-dir
   fix:
     target: ./scripts/truey
   description: Check your shell for basic functionality

--- a/examples/.scope/doctor-check-path-exists.yaml
+++ b/examples/.scope/doctor-check-path-exists.yaml
@@ -4,7 +4,7 @@ metadata:
   name: path-exists
 spec:
   check:
-    target: ./scripts/does-path-env-exist.sh
+    target: ./scripts/fail-first-call path-exists
   fix:
     target: ../bin/truey
   description: Check your shell for basic functionality

--- a/examples/.scope/doctor-group-1.yaml
+++ b/examples/.scope/doctor-group-1.yaml
@@ -1,23 +1,18 @@
 apiVersion: scope.github.com/v1alpha
 kind: ScopeDoctorGroup
 metadata:
-  name: foo
+  name: group-1
 spec:
   description: Check your shell for basic functionality
   actions:
     - description: foo1
       check:
-        paths:
-          - 'flig/bar/**/*'
         commands:
-          - ./foo1.sh
+          - ./scripts/fail-first-call foo
       fix:
         commands:
-          - ./fix1.sh
-      required: false
+          - ../bin/pip-install.sh
     - description: foo2
       check:
         paths:
-          - '*/*.txt'
-        commands:
-          - sleep infinity
+          - '**/requirements.txt'

--- a/examples/.scope/scripts/fail-first-call
+++ b/examples/.scope/scripts/fail-first-call
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eux
+
+NAME=$1
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+mkdir "${SCRIPT_DIR}/tmp" || true
+
+if [ -f "${SCRIPT_DIR}/tmp/${NAME}" ]; then
+  exit 0
+else
+  touch "${SCRIPT_DIR}/tmp/${NAME}"
+  exit 1
+fi

--- a/examples/.scope/scripts/falsey
+++ b/examples/.scope/scripts/falsey
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 1

--- a/scope-doctor/src/check.rs
+++ b/scope-doctor/src/check.rs
@@ -1,7 +1,7 @@
-use std::cmp;
-use std::cmp::max;
 use crate::file_cache::{CacheStorage, FileCacheStatus};
 use anyhow::Result;
+use std::cmp;
+use std::cmp::max;
 
 use colored::Colorize;
 #[cfg(not(test))]
@@ -118,7 +118,7 @@ impl<'a> DoctorActionRun<'a> {
     }
 
     pub async fn run_fixes(&self) -> Result<CorrectionResults, RuntimeError> {
-        if self.action.fix == None {
+        if self.action.fix.is_none() {
             return Ok(CorrectionResults::NoFixSpecified);
         }
 
@@ -226,17 +226,20 @@ impl<'a> DoctorActionRun<'a> {
             })
             .await?;
 
-            info!("check ran command {} and result was {:?}", command, output.exit_code);
+            info!(
+                "check ran command {} and result was {:?}",
+                command, output.exit_code
+            );
 
             let command_result = match output.exit_code {
                 Some(0) => CacheResults::FixNotRequired,
                 Some(100..=i32::MAX) => CacheResults::StopExecution,
-                _ => CacheResults::FixRequired
+                _ => CacheResults::FixRequired,
             };
 
             let next = match &result {
                 None => command_result,
-                Some(prev) => cmp::max(prev.clone(), command_result.clone())
+                Some(prev) => cmp::max(prev.clone(), command_result.clone()),
             };
 
             result.replace(next);

--- a/scope-doctor/src/check.rs
+++ b/scope-doctor/src/check.rs
@@ -1,3 +1,5 @@
+use std::cmp;
+use std::cmp::max;
 use crate::file_cache::{CacheStorage, FileCacheStatus};
 use anyhow::Result;
 
@@ -34,11 +36,11 @@ pub enum RuntimeError {
     PatternError(#[from] glob::PatternError),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Ord, Eq, PartialOrd)]
 pub enum CacheResults {
-    FixNotRequired,
-    FixRequired,
-    StopExecution,
+    FixNotRequired = 1,
+    FixRequired = 2,
+    StopExecution = 3,
 }
 
 impl CacheResults {
@@ -47,32 +49,12 @@ impl CacheResults {
     }
 }
 
-impl From<&OutputCapture> for CacheResults {
-    fn from(value: &OutputCapture) -> Self {
-        match value.exit_code {
-            Some(0) => CacheResults::FixNotRequired,
-            Some(100..=i32::MAX) => CacheResults::StopExecution,
-            _ => CacheResults::FixRequired,
-        }
-    }
-}
-
 #[derive(Debug, PartialEq)]
 pub enum CorrectionResults {
     NoFixSpecified,
     Success,
-    Failure,
+    FailContinue,
     FailAndStop,
-}
-
-impl From<&OutputCapture> for CorrectionResults {
-    fn from(value: &OutputCapture) -> Self {
-        match value.exit_code {
-            Some(0) => CorrectionResults::Success,
-            Some(100..=i32::MAX) => CorrectionResults::FailAndStop,
-            _ => CorrectionResults::Failure,
-        }
-    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -92,35 +74,35 @@ pub struct DoctorActionRun<'a> {
 }
 
 impl<'a> DoctorActionRun<'a> {
-    #[instrument(skip_all, fields(check.name = self.model.name(), action.description = self.action.description ))]
+    #[instrument(skip_all, fields(model.name = self.model.name(), action.name = self.action.name, action.description = self.action.description ))]
     pub async fn run_action(&self) -> Result<ActionRunResult> {
         let check_status = self.evaluate_checks().await?;
         let should_continue = match check_status {
             CacheResults::FixNotRequired => {
-                info!(target: "user", name = self.model.name(), "Check was successful.");
+                info!(target: "user", name = self.model.name(), "Check was successful");
                 ActionRunResult::Succeeded
             }
             CacheResults::FixRequired => {
                 if !self.run_fix {
-                    info!(target: "user", name = self.model.name(), "Check failed. {}: Run with --fix to auto-fix", "Suggestion".bold());
+                    info!(target: "user", group = self.model.name(), name = self.action.name,  "Check failed. {}: Run with --fix to auto-fix", "Suggestion".bold());
                     ActionRunResult::Succeeded
                 } else {
                     let fix_results = self.run_fixes().await?;
                     match fix_results {
                         CorrectionResults::Success => {
-                            info!(target: "user",name = self.model.name(), "Check failed. {} ran successfully.", "Fix".bold());
+                            info!(target: "user",group = self.model.name(), name = self.action.name, "Check failed. {} ran successfully", "Fix".bold());
                             ActionRunResult::Succeeded
                         }
                         CorrectionResults::NoFixSpecified => {
-                            info!(target: "user", name = self.model.name(), "Check failed. No fix was specified.");
+                            info!(target: "user", group = self.model.name(), name = self.action.name, "Check failed. No fix was specified");
                             ActionRunResult::Stop
                         }
-                        CorrectionResults::Failure => {
-                            error!(target: "user", name = self.model.name(), "Check failed. The fix ran and {}.", "Failed".red().bold());
+                        CorrectionResults::FailContinue => {
+                            error!(target: "user", group = self.model.name(), name = self.action.name, "Check failed. The fix ran and {}", "Failed".red().bold());
                             ActionRunResult::Failed
                         }
                         CorrectionResults::FailAndStop => {
-                            error!(target: "user", name = self.model.name(), "Check failed. The fix ran and {}. The fix exited with a 'stop' code, skipping remaining checks.", "Failed".red().bold());
+                            error!(target: "user", group = self.model.name(), name = self.action.name, "Check failed. The fix ran and {}, and was required", "Failed".red().bold());
                             ActionRunResult::Stop
                         }
                     }
@@ -136,32 +118,44 @@ impl<'a> DoctorActionRun<'a> {
     }
 
     pub async fn run_fixes(&self) -> Result<CorrectionResults, RuntimeError> {
-        let mut output = None;
+        if self.action.fix == None {
+            return Ok(CorrectionResults::NoFixSpecified);
+        }
+
+        let mut highest_exit_code = 0;
         if let Some(action_command) = &self.action.fix {
+            if action_command.commands.is_empty() {
+                return Ok(CorrectionResults::NoFixSpecified);
+            }
             for command in &action_command.commands {
                 let result = self.run_single_fix(command).await?;
-                match (result, &output) {
-                    (CorrectionResults::FailAndStop, _) => {
-                        return Ok(CorrectionResults::FailAndStop);
-                    }
-                    (CorrectionResults::Failure, _) => {
-                        output.replace(CorrectionResults::Failure);
-                    }
-                    (CorrectionResults::Success, None) => {
-                        output.replace(CorrectionResults::Success);
-                    }
-                    _ => {}
+                highest_exit_code = max(highest_exit_code, result);
+                if highest_exit_code >= 100 {
+                    return Ok(CorrectionResults::FailAndStop);
                 }
             }
         }
 
-        match output {
-            None => Ok(CorrectionResults::NoFixSpecified),
-            Some(v) => Ok(v),
+        if let Some(action_command) = &self.action.check.command {
+            let check_status = self.evaluate_command_check(action_command).await?;
+            info!("re-running check returned {:?}", check_status);
+            match check_status {
+                CacheResults::StopExecution => Ok(CorrectionResults::FailAndStop),
+                CacheResults::FixNotRequired => Ok(CorrectionResults::Success),
+                CacheResults::FixRequired => {
+                    if self.action.required {
+                        Ok(CorrectionResults::FailAndStop)
+                    } else {
+                        Ok(CorrectionResults::FailContinue)
+                    }
+                }
+            }
+        } else {
+            Ok(CorrectionResults::Success)
         }
     }
 
-    async fn run_single_fix(&self, command: &str) -> Result<CorrectionResults, RuntimeError> {
+    async fn run_single_fix(&self, command: &str) -> Result<i32, RuntimeError> {
         let args = vec![command.to_string()];
         let capture = OutputCapture::capture_output(CaptureOpts {
             working_dir: self.working_dir,
@@ -172,7 +166,9 @@ impl<'a> DoctorActionRun<'a> {
         })
         .await?;
 
-        Ok(CorrectionResults::from(&capture))
+        info!("fix ran {} and exited {:?}", command, capture.exit_code);
+
+        Ok(capture.exit_code.unwrap_or(-1))
     }
 
     pub async fn evaluate_checks(&self) -> Result<CacheResults, RuntimeError> {
@@ -217,6 +213,7 @@ impl<'a> DoctorActionRun<'a> {
         &self,
         action_command: &DoctorGroupActionCommand,
     ) -> Result<CacheResults, RuntimeError> {
+        let mut result: Option<CacheResults> = None;
         for command in &action_command.commands {
             let args = vec![command.clone()];
             let path = format!("{}:{}", self.model.containing_dir(), self.model.exec_path());
@@ -229,13 +226,26 @@ impl<'a> DoctorActionRun<'a> {
             })
             .await?;
 
-            let cache_results = CacheResults::from(&output);
-            if !cache_results.is_success() {
-                return Ok(cache_results);
+            info!("check ran command {} and result was {:?}", command, output.exit_code);
+
+            let command_result = match output.exit_code {
+                Some(0) => CacheResults::FixNotRequired,
+                Some(100..=i32::MAX) => CacheResults::StopExecution,
+                _ => CacheResults::FixRequired
+            };
+
+            let next = match &result {
+                None => command_result,
+                Some(prev) => cmp::max(prev.clone(), command_result.clone())
+            };
+
+            result.replace(next);
+            if result == Some(CacheResults::StopExecution) {
+                break;
             }
         }
 
-        Ok(CacheResults::FixRequired)
+        Ok(result.unwrap_or(CacheResults::FixRequired))
     }
 }
 

--- a/scope-doctor/src/commands/run.rs
+++ b/scope-doctor/src/commands/run.rs
@@ -76,6 +76,7 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
             match run.run_action().await? {
                 ActionRunResult::Stop => {
                     skip_remaining = true;
+                    should_pass = false;
                     break;
                 }
                 ActionRunResult::Failed => {

--- a/scope-lib/src/models/internal/doctor_group.rs
+++ b/scope-lib/src/models/internal/doctor_group.rs
@@ -3,19 +3,24 @@ use std::path::PathBuf;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct DoctorGroupAction {
+    pub name: String,
     pub description: String,
     pub fix: Option<DoctorGroupActionCommand>,
     pub check: DoctorGroupActionCheck,
+    pub required: bool
 }
 
 impl DoctorGroupAction {
     pub fn make_from(
+        name: &str,
         description: &str,
         fix_command: Option<Vec<&str>>,
         check_path: Option<(&str, Vec<&str>)>,
         check_command: Option<Vec<&str>>,
     ) -> Self {
         Self {
+            required: true,
+            name: name.to_string(),
             description: description.to_string(),
             fix: fix_command.map(|commands| DoctorGroupActionCommand {
                 commands: commands.iter().map(|x| x.to_string()).collect(),

--- a/scope-lib/src/models/internal/doctor_group.rs
+++ b/scope-lib/src/models/internal/doctor_group.rs
@@ -7,7 +7,7 @@ pub struct DoctorGroupAction {
     pub description: String,
     pub fix: Option<DoctorGroupActionCommand>,
     pub check: DoctorGroupActionCheck,
-    pub required: bool
+    pub required: bool,
 }
 
 impl DoctorGroupAction {

--- a/scope-lib/src/models/v1alpha/doctor_exec.rs
+++ b/scope-lib/src/models/v1alpha/doctor_exec.rs
@@ -42,6 +42,8 @@ pub(super) fn parse(base_path: &Path, value: &Value) -> Result<DoctorGroup> {
 
     Ok(DoctorGroup {
         actions: vec![DoctorGroupAction {
+            name: "1".to_string(),
+            required: true,
             description: parsed.description.clone(),
             fix: fix_exec,
             check: DoctorGroupActionCheck {
@@ -105,6 +107,7 @@ spec:
             DoctorGroup {
                 description: "Check your shell for basic functionality".to_string(),
                 actions: vec![DoctorGroupAction::make_from(
+                    "1",
                     "Check your shell for basic functionality",
                     Some(vec!["true"]),
                     None,
@@ -117,6 +120,7 @@ spec:
             DoctorGroup {
                 description: "Check your shell for basic functionality".to_string(),
                 actions: vec![DoctorGroupAction::make_from(
+                    "1",
                     "Check your shell for basic functionality",
                     None,
                     None,
@@ -129,6 +133,7 @@ spec:
             DoctorGroup {
                 description: "Check your shell for basic functionality".to_string(),
                 actions: vec![DoctorGroupAction::make_from(
+                    "1",
                     "Check your shell for basic functionality",
                     None,
                     None,

--- a/scope-lib/src/models/v1alpha/doctor_group.rs
+++ b/scope-lib/src/models/v1alpha/doctor_group.rs
@@ -49,11 +49,9 @@ pub(super) fn parse(containing_dir: &Path, value: &Value) -> Result<DoctorGroup>
     let parsed: DoctorGroupSpec = serde_yaml::from_value(value.clone())?;
 
     let mut actions: Vec<_> = Default::default();
-    let mut count = 0;
-    for spec_action in parsed.actions {
-        count += 1;
+    for (count, spec_action) in parsed.actions.into_iter().enumerate() {
         actions.push(DoctorGroupAction {
-            name: spec_action.name.unwrap_or_else(|| format!("{}", count)),
+            name: spec_action.name.unwrap_or_else(|| format!("{}", count + 1)),
             required: spec_action.required,
             description: spec_action
                 .description

--- a/scope-lib/src/models/v1alpha/doctor_setup.rs
+++ b/scope-lib/src/models/v1alpha/doctor_setup.rs
@@ -56,6 +56,8 @@ pub(super) fn parse(containing_dir: &Path, value: &Value) -> Result<DoctorGroup>
 
     Ok(DoctorGroup {
         actions: vec![DoctorGroupAction {
+            name: "1".to_string(),
+            required: true,
             description: parsed.description.clone(),
             fix: Some(exec),
             check: DoctorGroupActionCheck {
@@ -87,6 +89,8 @@ mod tests {
             DoctorGroup {
                 description: "Check your shell for basic functionality".to_string(),
                 actions: vec![DoctorGroupAction {
+                    name: "1".to_string(),
+                    required: true,
                     description: "Check your shell for basic functionality".to_string(),
                     fix: Some(DoctorGroupActionCommand::from(vec![
                         "/foo/bar/.scope/bin/setup"
@@ -114,6 +118,8 @@ mod tests {
             DoctorGroup {
                 description: "Check your shell for basic functionality".to_string(),
                 actions: vec![DoctorGroupAction {
+                    name: "1".to_string(),
+                    required: true,
                     description: "Check your shell for basic functionality".to_string(),
                     fix: Some(DoctorGroupActionCommand::from(vec!["sleep infinity"])),
                     check: DoctorGroupActionCheck {

--- a/scope/tests/integration_tests.rs
+++ b/scope/tests/integration_tests.rs
@@ -91,7 +91,7 @@ fn test_run_check_path_exists() {
         .assert();
 
     result.success().stdout(predicate::str::contains(
-        "Check failed. Fix ran successfully, group: \"path-exists\", name: \"1\""
+        "Check failed. Fix ran successfully, group: \"path-exists\", name: \"1\"",
     ));
 
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
@@ -105,7 +105,7 @@ fn test_run_check_path_exists() {
         .assert();
 
     result.success().stdout(predicate::str::contains(
-        "Check failed. Fix ran successfully, group: \"path-exists-fix-in-scope-dir\", name: \"1\""
+        "Check failed. Fix ran successfully, group: \"path-exists-fix-in-scope-dir\", name: \"1\"",
     ));
 
     working_dir.close().unwrap();
@@ -136,7 +136,7 @@ fn test_run_setup() {
     result
         .success()
         .stdout(predicate::str::contains(
-            "Check failed. Fix ran successfully, group: \"setup\", name: \"1\""
+            "Check failed. Fix ran successfully, group: \"setup\", name: \"1\"",
         ))
         .stdout(predicate::str::contains("Failed to write updated cache to disk").not());
 
@@ -155,7 +155,7 @@ fn test_run_setup() {
         .assert();
 
     result.success().stdout(predicate::str::contains(
-        "Check failed. Fix ran successfully, group: \"setup\", name: \"1\""
+        "Check failed. Fix ran successfully, group: \"setup\", name: \"1\"",
     ));
 
     working_dir


### PR DESCRIPTION
This changes the default behavior of a command so that if it fails, execution will stop.

In the event that a step is optional, it can be set to `required: false`