### PR TITLE
Remove "log" at begging of run

### DIFF
--- a/scope/src/main.rs
+++ b/scope/src/main.rs
@@ -17,7 +17,7 @@ use scope_report::prelude::{report_root, ReportArgs};
 use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::path::Path;
-use tracing::{debug, error, info};
+use tracing::{debug, enabled, error, info, Level};
 
 /// (Oscilli)scope
 ///
@@ -72,10 +72,14 @@ async fn main() {
     dotenv::dotenv().ok();
     let opts = Cli::parse();
 
-    let _guard = opts
+    let (_guard, file_location) = opts
         .logging
         .configure_logging(&opts.config.get_run_id(), "root");
     let error_code = run_subcommand(opts).await;
+
+    if error_code != 0 || enabled!(Level::DEBUG) {
+        info!(target: "user", "More detailed logs at {}", file_location);
+    }
 
     std::process::exit(error_code);
 }


### PR DESCRIPTION
Now the "More detailed logs at ..." will only show up if debug is enabled or when the exit code is non-0.

The format of the output has also changed from a newline json file to human readable.

Closes https://github.com/ethankhall/scope/issues/36