### PR TITLE
Skip fix if cache is successful (not if failure)

### DIFF
--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -208,7 +208,7 @@ impl DefaultDoctorActionRun {
     async fn evaluate_checks(&self) -> Result<CacheResults, RuntimeError> {
         if let Some(cache_path) = &self.action.check.files {
             let result = self.evaluate_path_check(cache_path).await?;
-            if !result.is_success() {
+            if result.is_success() {
                 return Ok(result);
             }
         }

--- a/scope/tests/integration_tests.rs
+++ b/scope/tests/integration_tests.rs
@@ -155,7 +155,7 @@ fn test_run_setup() {
         .assert();
 
     result.success().stdout(predicate::str::contains(
-        "Check initially failed, fix was successful, group: \"setup\", name: \"1\"",
+        "Check was successful, group: \"setup\", name: \"1\"",
     ));
 
     working_dir


### PR DESCRIPTION
## Problem
Currently, `scope doctor run` seems to ignore the path cache results and always runs fixes. This can be slow, especially for some fix commands:
```
❯ scope doctor run
 INFO Check was successful, group: "homebrew", name: "homebrew"
 INFO Check was successful, group: "github-ssh", name: "github-ssh"
 INFO Check was successful, group: "aws-sso", name: "aws-sso"
 INFO Check was successful, group: "node-version", name: "node-version"
Installing from the API is now the default behaviour!
You can save space and time by running:
  brew untap homebrew/core
  brew untap homebrew/cask
Already up-to-date.
Using homebrew/bundle
Using homebrew/cask
Using homebrew/core
Using homebrew/services
Using gusto/gusto
Using imagemagick@6
Using postgresql@14
Using wkhtmltopdf
Using rbenv
Using ghostscript
Using redis
Using nvm
Using gusto/gusto/pdftk
Using chromedriver
Using pkg-config
Using shellcheck
Using shared-mime-info
Using libsodium
Using overmind
Using libvips
Using mupdf
Homebrew Bundle complete! 21 Brewfile dependencies now installed.
 INFO Check initially failed, fix was successful, group: "brewfile", name: "brew-bundle"
yarn install v1.22.19
[1/5] Validating package.json...
[2/5] Resolving packages...
success Already up-to-date.
Done in 0.35s.
 INFO Check initially failed, fix was successful, group: "yarn-install", name: "yarn-install"
...
```

## Solution
Remove the negation that maps an unsuccessful file cache result to a successful cache result. Now:
```
❯ ~/workspace/scope/target/debug/scope doctor run
 INFO Check was successful, group: "homebrew", name: "homebrew"
 INFO Check was successful, group: "github-ssh", name: "github-ssh"
 INFO Check was successful, group: "aws-sso", name: "aws-sso"
 INFO Check was successful, group: "node-version", name: "node-version"
 INFO Check was successful, group: "brewfile", name: "brew-bundle"
 INFO Check was successful, group: "yarn-install", name: "yarn-install"
 INFO Check was successful, group: "redis", name: "redis"
 INFO Check was successful, group: "rbenv", name: "rbenv"
 INFO Check was successful, group: "postgres", name: "postgres"
 INFO Check was successful, group: "ruby-version", name: "ruby-version"
 INFO Check was successful, group: "dev-databases", name: "dev-databases-exist"
 INFO Check was successful, group: "dev-databases", name: "dev-databases-schema"
 INFO Check was successful, group: "dev-databases", name: "dev-databases-migrations"
 INFO Check was successful, group: "bundler", name: "bundler"
 INFO Check was successful, group: "bundle-install", name: "bundle-install"
```