### PR TITLE
chore: release v2024.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "dev-scope"
-version = "2024.2.8"
+version = "2024.2.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/scope/CHANGELOG.md
+++ b/scope/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2024.2.9] - 2024-03-13
+
 ## [2024.2.8] - 2024-03-05
 
 ## [2024.2.7] - 2024-02-15

--- a/scope/Cargo.toml
+++ b/scope/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dev-scope"
-version = "2024.2.8"
+version = "2024.2.9"
 edition = "2021"
 default-run = "scope"
 repository =  "https://github.com/ethankhall/scope"


### PR DESCRIPTION
## 🤖 New release
* `dev-scope`: 2024.2.8 -> 2024.2.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2024.2.9] - 2024-03-13


</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).