### PR TITLE
Load "shared" config files relative to executable

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -32,6 +32,8 @@ Currently, the only supported `apiVersion` is `scope.github.com/v1alpha`. Using 
 
 Unlike Kubernetes, the `name` field can be any string, without any DNS related constraints.
 
+Additionally, scope will look for shared config in the directory `../etc/scope` relative to where the executable is located.
+
 ## CLI Options
 All commands support the following options
 

--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -139,8 +139,9 @@ impl FoundConfig {
         let default_path = std::env::var("PATH").unwrap_or_default();
 
         let mut config_path = config_path.to_vec();
-        let exe_path = std::env::current_exe().unwrap_or_default().join("../etc/scope");
-        config_path.push(exe_path);
+        let exe_path = std::env::current_exe().unwrap();
+        let shared_path = exe_path.parent().unwrap().join("../etc/scope");
+        config_path.push(shared_path);
 
         let scope_path = config_path
             .iter()

--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -137,6 +137,11 @@ impl FoundConfig {
         config_path: Vec<PathBuf>,
     ) -> Self {
         let default_path = std::env::var("PATH").unwrap_or_default();
+
+        let mut config_path = config_path.to_vec();
+        let exe_path = std::env::current_exe().unwrap_or_default().join("../etc/scope");
+        config_path.push(exe_path);
+
         let scope_path = config_path
             .iter()
             .map(|x| x.join("bin").display().to_string())


### PR DESCRIPTION
Following on https://github.com/ethankhall/scope/discussions/74, this PR updates `scope` to also search for config files relative to it's current executable path.

## Testing

I was able to verify this change manually with a debug build locally.

### Shared config is present


```
❯ tree ~/workspace/gusto_scope_config
/Users/adam.neumann/workspace/gusto_scope_config
├── bin
│   └── scope
└── etc
    └── scope
        └── homebrew.yaml

❯ ~/workspace/gusto_scope_config/bin/scope doctor list
 INFO Available checks that will run
 INFO   Name                       Description                                                 Path
 INFO - ScopeDoctorGroup/homebrew  Homebrew                                                    ../gusto_scope_config/bin/../etc/scope/homebrew.yaml
```

### Shared config is missing

```
/Users/adam.neumann/workspace/gusto_scope_config
├── bin
│   └── scope
└── etc

❯ ~/workspace/gusto_scope_config/bin/scope doctor list
 INFO Available checks that will run
 INFO   Name                  Description                                                 Path
```